### PR TITLE
Delete rebar.config.script

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,8 +1,0 @@
-case erlang:function_exported(rebar3, main, 1) of
-    true -> % rebar3
-        CONFIG;
-    false -> % rebar 2.x
-        [{deps, [
-            {gun, ".*", {git, "https://github.com/ninenines/gun.git", "1.3.0"}}
-        ]} | lists:keydelete(deps, 1, CONFIG)]
-end.


### PR DESCRIPTION
This file is apparently for rebar2 compatibility, however the check that it is using to detect rebar2 vs. rebar3 does not work when it is actually Mix evaluating the script!  When mix invokes rebar to actually build the library, it does work and gun 2 is used as expected.  However when mix is trying to resolve dependencies, it uses the information that it gets from executing rebar.config.script itself, and will wrongly assume that shotgun is using gun 1.3 always.  Deleting the file will stop this from happening, as well as break rebar2 compatibility, but we don't care about that.